### PR TITLE
Braze

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,7 @@ load("@rules_jvm_external//:specs.bzl", "maven")
 maven_artifacts = (
     [
         maven.artifact("junit", "junit", "4.13", testonly = True),
+        'com.appboy:android-sdk-ui:22.0.0',
     ]
 )
 

--- a/android/app/BUILD.bazel
+++ b/android/app/BUILD.bazel
@@ -5,6 +5,7 @@ kt_android_library(
     srcs = ["MainActivity.kt"],
     visibility = ["//visibility:private"],
     deps = [
+        "@maven//:com_appboy_android_sdk_ui",
     ],
 )
 


### PR DESCRIPTION
This...builds!

```
$ bazel build android/app:all
INFO: Analyzed 4 targets (70 packages loaded, 1489 targets configured).
INFO: Found 4 targets...
INFO: From Desugaring external/maven/_aar/com_appboy_android_sdk_ui/classes_and_libs_merged.jar for Android:
Warning in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_aar/com_appboy_android_sdk_ui/classes_and_libs_merged.jar:com/braze/push/BrazeFirebaseMessagingService.class:
Type `com.google.firebase.messaging.FirebaseMessagingService` was not found, it is required for default or static interface methods desugaring of `com.braze.push.BrazeFirebaseMessagingService`
INFO: From Desugaring external/maven/_aar/com_appboy_android_sdk_base/classes_and_libs_merged.jar for Android:
Warning in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_aar/com_appboy_android_sdk_base/classes_and_libs_merged.jar:bo/app/l1.class:
Type `com.google.android.gms.tasks.OnFailureListener` was not found, it is required for default or static interface methods desugaring of `bo.app.l1$$InternalSyntheticLambda$2$d52fd81a2e0b8817bf94c3ea11494bf48d8b32d0713d3d8c6e4eb21c87de6d1f$1`
Warning in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_aar/com_appboy_android_sdk_base/classes_and_libs_merged.jar:bo/app/l1.class:
Type `com.google.android.gms.tasks.OnSuccessListener` was not found, it is required for default or static interface methods desugaring of `bo.app.l1$$InternalSyntheticLambda$2$2d45e37c07dbe7a6e08d63447beef010e29b09a3849d5069e29302776689a9c3$0`
Warning in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_aar/com_appboy_android_sdk_base/classes_and_libs_merged.jar:bo/app/e1.class:
Type `com.google.android.gms.tasks.OnCompleteListener` was not found, it is required for default or static interface methods desugaring of `bo.app.e1$$InternalSyntheticLambda$2$6b7a5fad0d4bf93c7d9108ba25dc3b0ac64323227232dd73adf4452f3a170dd4$0`
INFO: From Desugaring v1/https/repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.1/kotlinx-coroutines-core-jvm-1.6.1.jar for Android:
Warning in external/maven/v1/https/repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.1/kotlinx-coroutines-core-jvm-1.6.1.jar:kotlinx/coroutines/internal/ClassValueCtorCache$cache$1.class:
Type `java.lang.ClassValue` was not found, it is required for default or static interface methods desugaring of `kotlinx.coroutines.internal.ClassValueCtorCache$cache$1`
Warning in external/maven/v1/https/repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.1/kotlinx-coroutines-core-jvm-1.6.1.jar:kotlinx/coroutines/debug/AgentPremain$DebugProbesTransformer.class:
Type `java.lang.instrument.ClassFileTransformer` was not found, it is required for default or static interface methods desugaring of `kotlinx.coroutines.debug.AgentPremain$DebugProbesTransformer`
Warning in external/maven/v1/https/repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.1/kotlinx-coroutines-core-jvm-1.6.1.jar:kotlinx/coroutines/debug/AgentPremain.class:
Type `sun.misc.SignalHandler` was not found, it is required for default or static interface methods desugaring of `kotlinx.coroutines.debug.AgentPremain$$InternalSyntheticLambda$2$7895cd395e43c061a299e224a1d3672f97bd4610fe97f0e188c9c199a1620b54$0`
INFO: From Dexing external/maven/_dx/androidx_viewpager_viewpager/classes_and_libs_merged.jar_desugared.jar with applicable dexopts []:
Info: Stripped invalid locals information from 1 method.
Info in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_dx/androidx_viewpager_viewpager/classes_and_libs_merged.jar_desugared.jar:androidx/viewpager/widget/PagerTitleStrip.class:
Methods with invalid locals information:
  void androidx.viewpager.widget.PagerTitleStrip.updateTextPositions(int, float, boolean)
  Information in locals-table is invalid with respect to the stack map table. Local refers to non-present stack map type for register: 37 with constraint INT.
Info: Some warnings are typically a sign of using an outdated Java toolchain. To fix, recompile the source with an updated toolchain.
INFO: From Dexing external/maven/_dx/org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm/kotlinx-coroutines-core-jvm-1.6.1.jar_desugared.jar with applicable dexopts []:
Info: Stripped invalid locals information from 1 method.
Info in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_dx/org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm/kotlinx-coroutines-core-jvm-1.6.1.jar_desugared.jar:kotlinx/coroutines/JobSupport$children$1.class:
Methods with invalid locals information:
  java.lang.Object kotlinx.coroutines.JobSupport$children$1.invokeSuspend(java.lang.Object)
  Information in locals-table is invalid with respect to the stack map table. Local refers to non-present stack map type for register: 2 with constraint OBJECT.
Info: Some warnings are typically a sign of using an outdated Java toolchain. To fix, recompile the source with an updated toolchain.
Info: Stripped invalid locals information from 1 method.
Info in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_dx/org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm/kotlinx-coroutines-core-jvm-1.6.1.jar_desugared.jar:kotlinx/coroutines/flow/FlowKt__BuildersKt$asFlow$$inlined$unsafeFlow$10.class:
Methods with invalid locals information:
  java.lang.Object kotlinx.coroutines.flow.FlowKt__BuildersKt$asFlow$$inlined$unsafeFlow$10.collect(kotlinx.coroutines.flow.FlowCollector, kotlin.coroutines.Continuation)
  Attempt to define local of type long as element$iv:java.lang.Object
Info: Some warnings are typically a sign of using an outdated Java toolchain. To fix, recompile the source with an updated toolchain.
Info: Stripped invalid locals information from 1 method.
Info in bazel-out/android-armeabi-v7a-fastbuild/bin/external/maven/_dx/org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm/kotlinx-coroutines-core-jvm-1.6.1.jar_desugared.jar:kotlinx/coroutines/flow/FlowKt__BuildersKt$asFlow$$inlined$unsafeFlow$9.class:
Methods with invalid locals information:
  java.lang.Object kotlinx.coroutines.flow.FlowKt__BuildersKt$asFlow$$inlined$unsafeFlow$9.collect(kotlinx.coroutines.flow.FlowCollector, kotlin.coroutines.Continuation)
  Attempt to define local of type int as element$iv:java.lang.Object
Info: Some warnings are typically a sign of using an outdated Java toolchain. To fix, recompile the source with an updated toolchain.
INFO: Elapsed time: 41.106s, Critical Path: 21.65s
INFO: 639 processes: 53 internal, 491 darwin-sandbox, 95 worker.
INFO: Build completed successfully, 639 total actions
```