### PR TITLE
Demonstrate Dex Error

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,8 +19,7 @@ rules_proto_toolchains()
 android_sdk_repository(
     name = "androidsdk",
     api_level = 31,
-    build_tools_version = "30.0.3",  # Build tools 31+ is not supported? https://github.com/bazelbuild/bazel/issues/10240#issuecomment-884419566
-    # build_tools_version = "32.0.0",
+    build_tools_version = "33.0.0",
 )
 
 http_archive(

--- a/android/app/BUILD.bazel
+++ b/android/app/BUILD.bazel
@@ -12,5 +12,4 @@ android_binary(
     name = "app",
     deps = [":lib"],
     manifest = "AndroidManifest.xml",
-    dex_shards = 2,
 )

--- a/android/app/BUILD.bazel
+++ b/android/app/BUILD.bazel
@@ -12,4 +12,5 @@ android_binary(
     name = "app",
     deps = [":lib"],
     manifest = "AndroidManifest.xml",
+    dex_shards = 2,
 )


### PR DESCRIPTION
This builds. But if you check out the first commit in this PR (or change `dex_shards` to the default of 1), you get the following error:

```
$ bazel build android/app
INFO: Analyzed target //android/app:app (1 packages loaded, 113 targets configured).
INFO: Found 1 target...
ERROR: /private/var/tmp/_bazel_p/afc4c6dd0737eebec931aeb282f26bc9/external/androidsdk/BUILD.bazel:13:25: Extracting interface @androidsdk//:dx_jar_import [for tool] failed: missing input file '@androidsdk//:build-tools/31.0.0/lib/dx.jar'
ERROR: /private/var/tmp/_bazel_p/afc4c6dd0737eebec931aeb282f26bc9/external/androidsdk/BUILD.bazel:13:25: Extracting interface @androidsdk//:dx_jar_import [for tool] failed: 1 input file(s) do not exist
Target //android/app:app failed to build
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /private/var/tmp/_bazel_p/afc4c6dd0737eebec931aeb282f26bc9/external/androidsdk/BUILD.bazel:13:25 Extracting interface @androidsdk//:dx_jar_import [for tool] failed: 1 input file(s) do not exist
INFO: Elapsed time: 1.169s, Critical Path: 0.05s
INFO: 18 processes: 16 internal, 2 darwin-sandbox.
FAILED: Build did NOT complete successfully
```