### PR TITLE
Manifest merger issue

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,5 +3,7 @@ build --define=android_incremental_dexing_tool=d8_dexbuilder
 build --define=android_standalone_dexing_tool=d8_compat_dx
 build --nouse_workers_with_dexbuilder
 
+build --android_manifest_merger_order=dependency
+
 build --experimental_google_legacy_api
 query --experimental_google_legacy_api

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,8 @@ load("@rules_jvm_external//:specs.bzl", "maven")
 maven_artifacts = (
     [
         maven.artifact("junit", "junit", "4.13", testonly = True),
+        "androidx.emoji2:emoji2:1.2.0",
+        "androidx.lifecycle:lifecycle-process:2.2.0",
     ]
 )
 

--- a/android/app/BUILD.bazel
+++ b/android/app/BUILD.bazel
@@ -5,6 +5,8 @@ kt_android_library(
     srcs = ["MainActivity.kt"],
     visibility = ["//visibility:private"],
     deps = [
+        "@maven//:androidx_emoji2_emoji2",
+        "@maven//:androidx_lifecycle_lifecycle_process",
     ],
 )
 

--- a/android/app/BUILD.bazel
+++ b/android/app/BUILD.bazel
@@ -14,4 +14,7 @@ android_binary(
     name = "app",
     deps = [":lib"],
     manifest = "AndroidManifest.xml",
+    manifest_values = {
+        "applicationId": "com.ergatta.demo",
+    }
 )


### PR DESCRIPTION
3c9cdee produces a build failure

```
ERROR: /Users/p/Code/examples/barest-kotlin/android/app/BUILD.bazel:14:15: Merging manifest for //android/app:app failed: (Exit 1): ResourceProcessorBusyBox failed: error executing command (from target //android/app:app) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/bazel_tools/src/tools/android/java/com/google/devtools/build/android/ResourceProcessorBusyBox --tool MERGE_MANIFEST -- --manifest ... (remaining 7 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Error: /private/var/tmp/_bazel_p/afc4c6dd0737eebec931aeb282f26bc9/sandbox/darwin-sandbox/455/execroot/__main__/android/app/AndroidManifest.xml:20:19-74 Error:
	Attribute provider#androidx.startup.InitializationProvider@authorities value=(androidx.startup.androidx-startup) from [@maven//:androidx_startup_startup_runtime] AndroidManifest13915260121362870255.xml:20:19-74
	is also present at [@maven//:androidx_lifecycle_lifecycle_process] AndroidManifest2288743909190920066.xml:20:19-74 value=(androidx.lifecycle.process.androidx-startup).
	Suggestion: add 'tools:replace="android:authorities"' to <provider> element at AndroidManifest.xml:20:9-175 to override.
Sep 01, 2022 6:20:14 AM com.google.devtools.build.android.ResourceProcessorBusyBox processRequest
SEVERE: Error during processing
com.google.devtools.build.android.AndroidManifestProcessor$ManifestProcessingException: Manifest merger failed : Attribute provider#androidx.startup.InitializationProvider@authorities value=(androidx.startup.androidx-startup) from [@maven//:androidx_startup_startup_runtime] AndroidManifest13915260121362870255.xml:20:19-74
	is also present at [@maven//:androidx_lifecycle_lifecycle_process] AndroidManifest2288743909190920066.xml:20:19-74 value=(androidx.lifecycle.process.androidx-startup).
	Suggestion: add 'tools:replace="android:authorities"' to <provider> element at AndroidManifest.xml:20:9-175 to override.
	at com.google.devtools.build.android.AndroidManifestProcessor.mergeManifest(AndroidManifestProcessor.java:186)
	at com.google.devtools.build.android.ManifestMergerAction.main(ManifestMergerAction.java:228)
	at com.google.devtools.build.android.ResourceProcessorBusyBox$Tool$5.call(ResourceProcessorBusyBox.java:97)
	at com.google.devtools.build.android.ResourceProcessorBusyBox.processRequest(ResourceProcessorBusyBox.java:251)
	at com.google.devtools.build.android.ResourceProcessorBusyBox.main(ResourceProcessorBusyBox.java:181)

Exception in thread "main" com.google.devtools.build.android.AndroidManifestProcessor$ManifestProcessingException: Manifest merger failed : Attribute provider#androidx.startup.InitializationProvider@authorities value=(androidx.startup.androidx-startup) from [@maven//:androidx_startup_startup_runtime] AndroidManifest13915260121362870255.xml:20:19-74
	is also present at [@maven//:androidx_lifecycle_lifecycle_process] AndroidManifest2288743909190920066.xml:20:19-74 value=(androidx.lifecycle.process.androidx-startup).
	Suggestion: add 'tools:replace="android:authorities"' to <provider> element at AndroidManifest.xml:20:9-175 to override.
	at com.google.devtools.build.android.AndroidManifestProcessor.mergeManifest(AndroidManifestProcessor.java:186)
	at com.google.devtools.build.android.ManifestMergerAction.main(ManifestMergerAction.java:228)
	at com.google.devtools.build.android.ResourceProcessorBusyBox$Tool$5.call(ResourceProcessorBusyBox.java:97)
	at com.google.devtools.build.android.ResourceProcessorBusyBox.processRequest(ResourceProcessorBusyBox.java:251)
	at com.google.devtools.build.android.ResourceProcessorBusyBox.main(ResourceProcessorBusyBox.java:181)
Warning:
See http://g.co/androidstudio/manifest-merger for more information about the manifest merger.
```

09a3d99 fixes it by adding applicationId.